### PR TITLE
Code review

### DIFF
--- a/mqtt/mqtt_server.c
+++ b/mqtt/mqtt_server.c
@@ -529,17 +529,20 @@ static void ICACHE_FLASH_ATTR MQTT_ClientCon_recv_cb(void *arg, char *pdata, uns
 		const char *password =
 		    mqtt_get_str(&clientcon->mqtt_state.in_buffer[2 + msg_used_len], &password_len);
 
-		if (password != NULL)
-		clientcon->connect_info.password = (char *)os_zalloc(password_len+1);
-		if (clientcon->connect_info.password != NULL) {
-		    os_memcpy(clientcon->connect_info.password, password, password_len);
-		    clientcon->connect_info.password[password_len] = '\0';
-		    MQTT_INFO("MQTT: Password %s\r\n", clientcon->connect_info.password);
+		if (password == NULL) {
+		    clientcon->connect_info.password = (char *)NULL;
 		} else {
-		    MQTT_ERROR("MQTT: Out of mem\r\n");
-		    msg_conn_ret = CONNECTION_REFUSE_SERVER_UNAVAILABLE;
-		    clientcon->connState = TCP_DISCONNECTING;
-		    break;
+		    clientcon->connect_info.password = (char *)os_zalloc(password_len+1);
+		    if (clientcon->connect_info.password != NULL) {
+		        os_memcpy(clientcon->connect_info.password, password, password_len);
+		        clientcon->connect_info.password[password_len] = '\0';
+		        MQTT_INFO("MQTT: Password %s\r\n", clientcon->connect_info.password);
+		    } else {
+		        MQTT_ERROR("MQTT: Out of mem\r\n");
+		        msg_conn_ret = CONNECTION_REFUSE_SERVER_UNAVAILABLE;
+		        clientcon->connState = TCP_DISCONNECTING;
+		        break;
+		    }	
 		}
 		msg_used_len += 2 + password_len;
 	    }


### PR DESCRIPTION
I am not sure whether this fixes the out of mem issue by adding the following condition of NULL password checking prior to the authentication callback.

		if (password == NULL) {
		    MQTT_WARNING("MQTT: Password invalid\r\n");
		    MQTT_server_disconnectClientCon(clientcon);
		    return;
		}

SJ